### PR TITLE
Logger & Serializer 0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Adding only a single dependency to your projects.
 - Using new, improved [net/http](https://pkg.go.dev/net/http) router
 - Group routes and scope-specific middlewares
 - Read and write json via the [encoding/json](https://pkg.go.dev/encoding/json)
-- Customizable with different `slog` configurations; bring your own serializer!
+- Highly customizable; bring your own logger and serializer!
 - Helper functions for commonly used HTTP status code responses
 - Featuring a built-in `validator` package for data validation
 
@@ -79,17 +79,20 @@ It is possible customize Grape for different use-cases. You can view more inside
 
 ## Composability
 
-Grape consists of several components independent of each other. Giving developers opt-in choice of features.
+Grape consists of several components independent of each other. Giving developers **opt-in choice of features**.
 
 ### `grape.Server`
 
-Providing methods for logging, interacting with json, common HTTP responses and some other useful utilities.  
-An instance of it is created by running `grape.New()`. It can be embedded inside a struct, placed as a regular field,
-or even being passed around through the context.
+Providing methods for logging, interacting with json, common HTTP responses and some other useful utilities. 
+It can be embedded inside a struct, placed as a regular field, instantiate as a global variable,
+or even being passed around through the context.  
+An instance of it is created by running `grape.New()` and its behaviour is customizable by passing `grape.Options` 
+as an argument.
 
 ### `*grape.Router`
 
-Enable routing via methods named after HTTP verbs, with route grouping and scope-specific middlewares.  
+Enable routing via methods named after HTTP verbs, with route grouping and scope-specific middlewares.
+Create a new instance by running `grape.NewRouter()`.  
 All routes are registered on server's startup and the rest is handled by the standard library,
 causing zero runtime overhead.
 

--- a/_examples/advanced_server/logger.go
+++ b/_examples/advanced_server/logger.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+// logger embeds standard log.Logger, and it also implements grape.Logger.
+// Any other logging packages can be used as well.
+type logger struct {
+	*log.Logger
+}
+
+func newLogger() logger {
+	return logger{
+		Logger: log.New(os.Stdout, "", log.LstdFlags),
+	}
+}
+
+func (l logger) Debug(msg string, args ...any) {
+	l.log("Debug", msg, args...)
+}
+
+func (l logger) Info(msg string, args ...any) {
+	l.log("Info", msg, args...)
+}
+
+func (l logger) Warn(msg string, args ...any) {
+	l.log("Warn", msg, args...)
+}
+
+func (l logger) Error(msg string, args ...any) {
+	l.log("Error", msg, args...)
+}
+
+func (l logger) log(level, msg string, args ...any) {
+	m := append([]any{level + ":", msg}, args...)
+	l.Println(m...)
+}

--- a/_examples/advanced_server/main.go
+++ b/_examples/advanced_server/main.go
@@ -16,14 +16,19 @@ type handler struct {
 }
 
 func main() {
-	// Any valid *slog.Logger will do! You can configure the destination, log format, level and more.
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	var logOption grape.Logger
+	// Any valid grape.Logger will do! Since *slog.Logger implements it as well, it can be seamlessly used.
+	logOption = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	// Any valid grape.serializer will do! (check out serializer.go for the implementation).
-	serializer := Jsoniter{}
+	// Or rather, create a custom type that implements grape.Logger with packages of your choice.
+	// (check out logger.go for the implementation)
+	// logOption = newLogger()
 
-	// If you don't provide a field, default value (grape.defaultOptions) will be used.
-	opts := grape.Options{Log: logger, Serialize: serializer}
+	// Any valid grape.Serializer will do! (check out serializer.go for the implementation).
+	serializeOption := newSerializer()
+
+	// If you don't provide a field, default value will be used.
+	opts := grape.Options{Log: logOption, Serialize: serializeOption}
 
 	// Instantiate the grape.Server inside your struct of choice.
 	h := handler{

--- a/_examples/advanced_server/routes.go
+++ b/_examples/advanced_server/routes.go
@@ -23,6 +23,8 @@ func (h *handler) createPermitHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) getPermitByID(w http.ResponseWriter, r *http.Request) {
+	h.Debug("getPermitByID handler")
+
 	pid := h.ParamInt64(r, "pid")
 	if pid == 0 {
 		h.Info("get_permit_handler", "error", "invalid parameter")

--- a/_examples/advanced_server/serializer.go
+++ b/_examples/advanced_server/serializer.go
@@ -1,80 +1,38 @@
 package main
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"strings"
-	"time"
 
 	jsoniter "github.com/json-iterator/go"
 )
 
-// Jsoniter implements grape.serializer.
+// serializer implements grape.Serializer.
 // I have intentionally used an external dependency just to demonstrate you can use anything you would like.
-type Jsoniter struct{}
+type serializer struct{}
 
-func (Jsoniter) WriteJson(w http.ResponseWriter, status int, data any, _ http.Header) error {
+func newSerializer() serializer {
+	return serializer{}
+}
+
+func (serializer) WriteJson(w http.ResponseWriter, status int, data any, _ http.Header) error {
 	js, err := jsoniter.Marshal(data)
 	if err != nil {
 		return nil
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Date", time.Now().Format(http.TimeFormat))
 
 	w.WriteHeader(status)
 	_, err = w.Write(js)
 	return err
 }
-func (Jsoniter) ReadJson(w http.ResponseWriter, r *http.Request, dst any) error {
-	maxBytes := 1_048_576
-	r.Body = http.MaxBytesReader(w, r.Body, int64(maxBytes))
+func (serializer) ReadJson(_ http.ResponseWriter, r *http.Request, dst any) error {
 	dec := jsoniter.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 
 	err := dec.Decode(dst)
 	if err != nil {
-		var syntaxError *json.SyntaxError
-		var unmarshalTypeError *json.UnmarshalTypeError
-		var invalidUnmarshalError *json.InvalidUnmarshalError
-
-		switch {
-		case errors.As(err, &syntaxError):
-			return fmt.Errorf("body contains badly-formed JSON (at character %d)", syntaxError.Offset)
-
-		case errors.Is(err, io.ErrUnexpectedEOF):
-			return errors.New("body contains badly-formed JSON")
-
-		case errors.As(err, &unmarshalTypeError):
-			if unmarshalTypeError.Field != "" {
-				return fmt.Errorf("body contains incorrect JSON type for field %q", unmarshalTypeError.Field)
-			}
-			return fmt.Errorf("body contains incorrect JSON type (at character %d)", unmarshalTypeError.Offset)
-
-		case errors.Is(err, io.EOF):
-			return errors.New("body must not be empty")
-
-		case strings.HasPrefix(err.Error(), "json: unknown field "):
-			fieldName := strings.TrimPrefix(err.Error(), "json: unknown field ")
-			return fmt.Errorf("body contains unknown key %s", fieldName)
-
-		case err.Error() == "http: request body too large":
-			return fmt.Errorf("body must not be larger than %d bytes", maxBytes)
-
-		case errors.As(err, &invalidUnmarshalError):
-			return err
-
-		default:
-			return err
-		}
-	}
-
-	err = dec.Decode(&struct{}{})
-	if err != io.EOF {
-		return errors.New("body must only contain a single JSON value")
+		return err
 	}
 
 	return nil

--- a/_examples/simple_server/main.go
+++ b/_examples/simple_server/main.go
@@ -49,21 +49,22 @@ func (h *handler) parameterHandler(w http.ResponseWriter, r *http.Request) {
 		h.NotFoundResponse(w)
 		return
 	}
-	h.CreatedResponse(w, grape.Map{"id": id})
+	h.CreatedResponse(w, id)
 }
 
 func (h *handler) pingHandler(w http.ResponseWriter, r *http.Request) {
 	type request struct {
-		Ping string `json:"ping"`
+		Data string `json:"data"`
 	}
 
 	var req request
 	err := h.ReadJson(w, r, &req)
 	if err != nil {
+		h.Error("ping handler", "error reading request", err)
 		h.BadRequestResponse(w, err)
 		return
 	}
 
-	h.Warn("ping handler", "request", req.Ping)
-	h.NoContentResponse(w)
+	h.Info("ping handler", "request", req.Data)
+	h.OkResponse(w, grape.Map{"ping": "pong", "data": req.Data})
 }

--- a/grape.go
+++ b/grape.go
@@ -1,4 +1,5 @@
 // Package grape is a modern, zero-dependency HTTP library for Go.
+// Visit https://github.com/hossein1376/grape for more information.
 package grape
 
 import (
@@ -11,51 +12,70 @@ import (
 // Map is an alias type and is intended for json response marshalling.
 type Map = map[string]any
 
-// Server is main struct of Grape with three embedded private types; logger, serializer and response.
-// It should be included in the same struct that your handlers are a method to,
+// Server is the main struct of Grape with three embedded types; Logger, Serializer and response.
+// Main usage pattern is to included it in the same struct that your handlers are a method to,
 // so the helper methods are accessible through the receiver.
 type Server struct {
-	logger
-	serializer
+	Logger
+	Serializer
 	response
 }
 
-// Options is used to customize Grape's settings, namely Log and Serialize.
-// If a field is not provided, the default will be used instead.
+// Options is used to customize Grape's settings, by passing down an instance of it to grape.New().
+//
+// Log should implement grape.Logger. Since slog.Logger automatically does,
+// all instances of it can be used. Alongside of any other custom types.
+// Default logger displays text logs to the standard output and in `info` level.
+//
+// Serialize should implement grape.Serializer.
+// Default serializer uses standard library `encoding/json` package.
+//
+// RequestMaxSize sets maximum request's body size in bytes. This value will be taken into effect only
+// if Serialize field was not provided.
+// Default size is 1_048_576 bytes (1 mb).
 type Options struct {
-	Log       *slog.Logger
-	Serialize serializer
+	Log            Logger
+	Serialize      Serializer
+	RequestMaxSize int64
 }
 
 var defaultOptions = Options{
-	// default logger displays text logs to the standard output and in `info` level
-	Log: slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})),
-	// default serialize uses standard library `encoding/json`
-	Serialize: serialize{},
+	Log:            slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	Serialize:      serializer{maxBytes: maxBodySize},
+	RequestMaxSize: maxBodySize,
 }
 
-// New return an instance of grape.Server to be included in structs.
-// It optionally accepts grape.Option to customize Grape's settings.
+// New returns a new instance of grape.Server.
+// It optionally accepts grape.Options to customize Grape's settings.
 func New(opts ...Options) Server {
 	var opt Options
+
+	// if no options was provided, proceed with the default values.
 	if len(opts) == 0 {
 		opt = defaultOptions
 	} else {
 		opt = opts[0]
 
+		// if Log field was not provided, use default logger.
 		if opt.Log == nil {
 			opt.Log = defaultOptions.Log
 		}
 
+		// if Serialize field was not provided, use default serializer.
 		if opt.Serialize == nil {
-			opt.Serialize = defaultOptions.Serialize
+			// if RequestMaxSize was not provided or an invalid value was given, use default value.
+			if opt.RequestMaxSize <= 0 {
+				opt.RequestMaxSize = defaultOptions.RequestMaxSize
+			}
+
+			opt.Serialize = serializer{maxBytes: opt.RequestMaxSize}
 		}
 	}
 
 	return Server{
-		serializer: opt.Serialize,
-		logger:     logger{opt.Log},
-		response:   newResponse(logger{opt.Log}, opt.Serialize),
+		Serializer: opt.Serialize,
+		Logger:     opt.Log,
+		response:   newResponse(opt.Log, opt.Serialize),
 	}
 }
 
@@ -69,7 +89,7 @@ func (server Server) ParamInt(r *http.Request, name string) int {
 	return param
 }
 
-// ParamInt64 extracts the parameter by its name from request and converts it to integer.
+// ParamInt64 extracts the parameter by its name from request and converts it to 64-bit integer.
 // It will return 0 if no parameter was found, or there was an error converting it to int64.
 func (server Server) ParamInt64(r *http.Request, name string) int64 {
 	param, err := strconv.ParseInt(r.PathValue(name), 10, 64)

--- a/logger.go
+++ b/logger.go
@@ -1,31 +1,9 @@
 package grape
 
-import (
-	"log/slog"
-)
-
-// logger is a wrapper struct around slog.Logger, exposing only handful APIs such as Info or Error.
-// This is an intentional design decision to tune down the number of available methods on Server.
-type logger struct {
-	slog *slog.Logger
-}
-
-// Debug logs at LevelDebug.
-func (log logger) Debug(msg string, args ...any) {
-	log.slog.Debug(msg, args...)
-}
-
-// Info logs at LevelInfo.
-func (log logger) Info(msg string, args ...any) {
-	log.slog.Info(msg, args...)
-}
-
-// Warn logs at LevelWarn.
-func (log logger) Warn(msg string, args ...any) {
-	log.slog.Warn(msg, args...)
-}
-
-// Error logs at LevelError.
-func (log logger) Error(msg string, args ...any) {
-	log.slog.Error(msg, args...)
+// Logger interface exposes methods in different log levels, following the convention of slog.Logger.
+type Logger interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
 }

--- a/response.go
+++ b/response.go
@@ -5,12 +5,12 @@ import (
 )
 
 type response struct {
-	logger
-	serializer
+	Logger
+	Serializer
 }
 
-func newResponse(logger logger, json serializer) response {
-	return response{logger: logger, serializer: json}
+func newResponse(logger Logger, json Serializer) response {
+	return response{Logger: logger, Serializer: json}
 }
 
 type resp struct {
@@ -18,7 +18,7 @@ type resp struct {
 }
 
 // Response is a general function which responses with the provided message and status code,
-// it will return 500 if case of failure.
+// it will return 500 in case of failure.
 func (res response) Response(w http.ResponseWriter, statusCode int, message any) {
 	err := res.WriteJson(w, statusCode, message, nil)
 	if err != nil {

--- a/serialize.go
+++ b/serialize.go
@@ -10,22 +10,29 @@ import (
 	"time"
 )
 
-// serializer interface consists of two methods, one for reading json inputs and one for writing json outputs.
-type serializer interface {
+// Serializer interface consists of two methods, one for reading json inputs and one for writing json outputs.
+type Serializer interface {
 	WriteJson(w http.ResponseWriter, status int, data any, headers http.Header) error
 	ReadJson(w http.ResponseWriter, r *http.Request, dst any) error
 }
 
-type serialize struct{}
+// serializer implements Serializer interface.
+type serializer struct {
+	maxBytes int64
+}
+
+// Default request's body maximum size, if not overridden by grape.Options.
+var maxBodySize int64 = 1_048_576
 
 // WriteJson will write back data in json format with the provided status code and headers.
-func (serialize) WriteJson(w http.ResponseWriter, status int, data any, headers http.Header) error {
+// It automatically sets content-type and date headers. To override, provide them as headers.
+func (serializer) WriteJson(w http.ResponseWriter, status int, data any, headers http.Header) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Date", time.Now().Format(http.TimeFormat))
+
 	for key, value := range headers {
 		w.Header()[key] = value
 	}
-
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Date", time.Now().Format(http.TimeFormat))
 
 	if data == nil {
 		w.WriteHeader(status)
@@ -43,9 +50,8 @@ func (serialize) WriteJson(w http.ResponseWriter, status int, data any, headers 
 }
 
 // ReadJson will decode incoming json requests. It will return a human-readable error in case of failure.
-func (serialize) ReadJson(w http.ResponseWriter, r *http.Request, dst any) error {
-	maxBytes := 1_048_576
-	r.Body = http.MaxBytesReader(w, r.Body, int64(maxBytes))
+func (s serializer) ReadJson(w http.ResponseWriter, r *http.Request, dst any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, s.maxBytes)
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 
@@ -56,11 +62,17 @@ func (serialize) ReadJson(w http.ResponseWriter, r *http.Request, dst any) error
 		var invalidUnmarshalError *json.InvalidUnmarshalError
 
 		switch {
-		case errors.As(err, &syntaxError):
-			return fmt.Errorf("body contains badly-formed JSON (at character %d)", syntaxError.Offset)
+		case errors.Is(err, io.EOF):
+			return errors.New("body must not be empty")
 
 		case errors.Is(err, io.ErrUnexpectedEOF):
 			return errors.New("body contains badly-formed JSON")
+
+		case errors.As(err, &invalidUnmarshalError):
+			return err
+
+		case errors.As(err, &syntaxError):
+			return fmt.Errorf("body contains badly-formed JSON (at character %d)", syntaxError.Offset)
 
 		case errors.As(err, &unmarshalTypeError):
 			if unmarshalTypeError.Field != "" {
@@ -68,18 +80,12 @@ func (serialize) ReadJson(w http.ResponseWriter, r *http.Request, dst any) error
 			}
 			return fmt.Errorf("body contains incorrect JSON type (at character %d)", unmarshalTypeError.Offset)
 
-		case errors.Is(err, io.EOF):
-			return errors.New("body must not be empty")
+		case err.Error() == "http: request body too large":
+			return fmt.Errorf("body must not be larger than %d bytes", s.maxBytes)
 
 		case strings.HasPrefix(err.Error(), "json: unknown field "):
 			fieldName := strings.TrimPrefix(err.Error(), "json: unknown field ")
 			return fmt.Errorf("body contains unknown key %s", fieldName)
-
-		case err.Error() == "http: request body too large":
-			return fmt.Errorf("body must not be larger than %d bytes", maxBytes)
-
-		case errors.As(err, &invalidUnmarshalError):
-			return err
 
 		default:
 			return err


### PR DESCRIPTION
Accepts interfaces in `grape.Options` struct.  Allowing for better customizability.   
Any types implementing `grape.Logger`, including `slog.Logger`, can be used for logging.  
Use `grape.Serializer` to configure reading and writing json; or to specify max body size.
Update examples and README file.