### PR TITLE
Fix header timeout vulnerability and add linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+# Enable all linters except the deprecated and annoying ones
+linters:
+  enable-all: true
+  disable:
+    # Deprecated
+    - nosnakecase
+    - exhaustivestruct
+    - varcheck
+    - interfacer
+    - structcheck
+    - maligned
+    - scopelint
+    - ifshort
+    - golint
+    - deadcode
+    # Disable for now and decide if it is worth to support them
+    - varnamelen
+    - paralleltest
+    - gochecknoglobals
+    - funlen
+    - lll
+    - wsl

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Print this help message
+	@echo "List of available make commands";
+	@echo "";
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}';
+	@echo "";
+
+.PHONY: lint
+lint: ## Lint the code and look for usual errors
+	golangci-lint run
+
+.PHONY: fmt
+fmt: ## Format the code using gofumpt
+	gofumpt -w -l .

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ help: ## Print this help message
 	@echo "";
 
 .PHONY: lint
-lint: ## Lint the code and look for usual errors
+lint: ## Lint the code and look for common errors
 	golangci-lint run
 
 .PHONY: fmt

--- a/_examples/advanced_server/serializer.go
+++ b/_examples/advanced_server/serializer.go
@@ -26,6 +26,7 @@ func (serializer) WriteJson(w http.ResponseWriter, status int, data any, _ http.
 	_, err = w.Write(js)
 	return err
 }
+
 func (serializer) ReadJson(_ http.ResponseWriter, r *http.Request, dst any) error {
 	dec := jsoniter.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()

--- a/router.go
+++ b/router.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"time"
 )
 
 // Router provides methods such as Get, Post and Use (among others) for routing.
@@ -126,7 +127,12 @@ func (r *Router) Serve(addr string, server ...*http.Server) error {
 		h = middleware(h)
 	}
 
-	srv := &http.Server{}
+	srv := &http.Server{
+		// A good value between Apache's and Nginx's defaults
+		// https://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_timeout
+		// https://httpd.apache.org/docs/2.4/mod/directive-dict.html#Default
+		ReadHeaderTimeout: time.Second * 45,
+	}
 	if len(server) != 0 {
 		srv = server[0]
 	}


### PR DESCRIPTION
Hi, while reading through your source, I noticed that you were not setting a timeout for reading the client's header.
This is a security vulnerability, since the server would chew on those in indefinitely.

Because these types of errors can be detected via golangci-lint, I added a configuration for it.
If you want, I would add my good documented nix flake as well, since it is useful to get the newest go version.

Feel free to make any changes. I tried to explain each change in the commit messages ^^