### PR TITLE
Return error as second value in ParamInt and ParamInt64

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ func main() {
 func (h *handler) paramHandler(w http.ResponseWriter, r *http.Request) {
 	h.Info("Param handler!")
 
-	id := h.ParamInt(r, "id")
-	if id == 0 {
+	id, err := h.ParamInt(r, "id")
+	if err != nil {
 		h.NotFoundResponse(w)
 		return
 	}

--- a/_examples/advanced_server/routes.go
+++ b/_examples/advanced_server/routes.go
@@ -25,8 +25,8 @@ func (h *handler) createPermitHandler(w http.ResponseWriter, r *http.Request) {
 func (h *handler) getPermitByID(w http.ResponseWriter, r *http.Request) {
 	h.Debug("getPermitByID handler")
 
-	pid := h.ParamInt64(r, "pid")
-	if pid == 0 {
+	pid, err := h.ParamInt64(r, "pid")
+	if err != nil {
 		h.Info("get_permit_handler", "error", "invalid parameter")
 		h.NotFoundResponse(w)
 		return

--- a/_examples/simple_server/main.go
+++ b/_examples/simple_server/main.go
@@ -44,8 +44,8 @@ func (h *handler) rootHandler(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (h *handler) parameterHandler(w http.ResponseWriter, r *http.Request) {
-	id := h.ParamInt(r, "id")
-	if id == 0 {
+	id, err := h.ParamInt(r, "id")
+	if err != nil {
 		h.NotFoundResponse(w)
 		return
 	}

--- a/grape.go
+++ b/grape.go
@@ -80,21 +80,21 @@ func New(opts ...Options) Server {
 }
 
 // ParamInt extracts the parameter by its name from request and converts it to integer.
-// It will return 0 if no parameter was found, or there was an error converting it to int.
-func (server Server) ParamInt(r *http.Request, name string) int {
+// It will return 0 and an error if no parameter was found, or there was an error converting it to int.
+func (server Server) ParamInt(r *http.Request, name string) (int, error) {
 	param, err := strconv.Atoi(r.PathValue(name))
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return param
+	return param, nil
 }
 
 // ParamInt64 extracts the parameter by its name from request and converts it to 64-bit integer.
-// It will return 0 if no parameter was found, or there was an error converting it to int64.
-func (server Server) ParamInt64(r *http.Request, name string) int64 {
+// It will return 0 and an error if no parameter was found, or there was an error converting it to int64.
+func (server Server) ParamInt64(r *http.Request, name string) (int64, error) {
 	param, err := strconv.ParseInt(r.PathValue(name), 10, 64)
 	if err != nil {
-		return 0
+		return 0, err
 	}
-	return param
+	return param, nil
 }


### PR DESCRIPTION
Use the Go pattern of signaling that something went wrong using an error parameter.